### PR TITLE
Update Makefile and installation instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ $(CMD):  deps generate www
 # convenience target for developers: `make run` runs the application with
 # environment options sourced from $PWD/.env
 run:$(CMD)
-	set -euo pipefail && .$(CMD) $*
+	set -euo pipefail && ./$(CMD) $*
 
 vendor: FORCE
 	$(GO) mod tidy

--- a/readme.md
+++ b/readme.md
@@ -2,16 +2,47 @@
 
 Conference management platform, bespoke for GopherCon, open source for all.
 
-## building
-`make manager` generates service files, builds the frontend, then compiles the app
+## How to Use
 
-## running
-start jaeger: `cd docker && docker-compose up -d`
-`make manager && make run`
+### Requirements
 
-## viewing
-[web app](https://127.0.0.1:8000/)
-[jaeger](https://127.0.0.1:16686/)
+* Go 1.15
+* Docker
+
+### Build
+
+To generate service files, build the front end and compile the app, run:
+
+```shell
+$ make manager
+```
+
+### Run
+Start Jaeger and Postgres: 
+```shell
+$ cd docker && docker-compose up -d
+```
+
+Jaeger must be running for the server to start.
+
+Start the manager server:
+```shell
+$ make run
+```
+
+### View
+
+To view the web app visit [here](http://127.0.0.1:8000/).
+
+To visit Jaeger, go [here](http://127.0.0.1:16686/).
+
+
+### Clean up
+
+To stop Jaeger and Postgres, run:
+```shell
+$ cd docker && docker-compose down
+```
 
 ## Coming Soon
 There isn't much to share yet.  Come back soon to see how you can participate.


### PR DESCRIPTION
## Description
Updated the run target in the Makefile from `set -euo pipefail && .$(CMD) $*` to `set -euo pipefail && ./$(CMD) $*` to resolve error when running `make run`.

Updated the readme to include up-to-date installation instructions and changed layout to improve readbility.

Changed links from https:// to http://.

